### PR TITLE
修正：ブラウザのウィンドウ幅を狭めた時、各ページで写真が文字の上に被らないように修正

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -3,6 +3,7 @@ $white: #fff;
 
 html {
   font-size: 80.5%;
+  min-width: 1100px;
 }
 body {
   width: 100%;

--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -3,7 +3,6 @@ $white: #fff;
 
 html {
   font-size: 80.5%;
-  min-width: 1100px;
 }
 body {
   width: 100%;

--- a/app/assets/stylesheets/record.scss
+++ b/app/assets/stylesheets/record.scss
@@ -57,13 +57,108 @@
   background-image: image_url('picture_left.jpg');
   background-size: cover;
 }
+.index_picture_margin {
+  margin: 0 30px;
+}
+.picture_position_right {
+  display: block;
+  border-radius: 10px;
+  position: fixed;
+  right: 30px;
+  top: 150px;
+}
+.picture_position_left {
+  display: block;
+  border-radius: 10px;
+  position: fixed;
+  left: 30px;
+  top: 150px;
+}
+.picture_position_left {
+  display: block;
+  border-radius: 10px;
+  position: fixed;
+  left: 30px;
+  top: 150px;
+}
+
+#record_food_id {
+  width: 149px;
+  height: 24px;
+}
+.ate_width {
+  width: 70px;
+}
+.show_text_width {
+  width: 70px;
+  text-align: center;
+}
+.show_text_protein {
+  width: 100px;
+}
+.picture_nostalgy {
+  width: 300px;
+  height: 450px;
+  background-image: image_url('picture_left.jpg');
+  background-size: cover;
+}
+.nostalsy_padding {
+  margin-right: 100px;
+}
+.day_record_style {
+  border: solid 3px green;
+  border-radius: 10px;
+}
+.border_bottom {
+  border-bottom: solid 3px green;
+}
+.border_top {
+  border-top: solid 3px green;
+}
+.my_target {
+  width: 270px;
+  height: 40px;
+  font-size: 1.5rem;
+  line-height: 38px;
+  text-decoration: underline dashed 3px rgb(152, 152, 21);
+  display: block;
+  border-radius: 10px;
+  position: fixed;
+  left: 0px;
+  top: 340px;
+}
+@media only screen and (max-width: 414px) {
+  .my_target {
+    top: auto;
+    display: block;
+    position: static;
+    left: 50%;
+    margin-left: -125px;
+    bottom: 10px;
+  }
+}
+
+.table_width {
+  min-width: 400px;
+}
+.record_th {
+  min-width: 45px;
+}
+.picture_left {
+  width: 210px;
+  height: 380px;
+  background-image: image_url('picture_left.jpg');
+  background-size: cover;
+}
 .sunflower {
+  display: block;
   width: 300px;
   height: 500px;
   background-image: image_url('sunflower.jpg');
   background-size: cover;
 }
 .camera {
+  display: block;
   width: 300px;
   height: 500px;
   background-image: image_url('camera.jpg');
@@ -95,8 +190,22 @@
 }
 .egg {
   position: fixed;
-  width: 20%;
+  display: block;
+  width: 300px;
   height: 500px;
   background-image: image_url('egg.jpg');
   background-size: cover;
+}
+@media only screen and (max-width: 1100px) {
+  .egg {
+    position: static;
+    width: 400px;
+    height: 400px;
+    background-position: 50% 100%;
+  }
+  .sunflower, .camera {
+    position: static;
+    width: 150px;
+    height: auto;
+  }
 }

--- a/app/assets/stylesheets/record.scss
+++ b/app/assets/stylesheets/record.scss
@@ -1,3 +1,5 @@
+@charset "utf-8";
+
 #record_food_id {
   width: 149px;
   height: 24px;
@@ -12,7 +14,6 @@
 .show_text_protein {
   width: 100px;
 }
-
 .picture_nostalgy {
   width: 300px;
   height: 450px;
@@ -22,7 +23,6 @@
 .nostalsy_padding {
   margin-right: 100px;
 }
-
 .day_record_style {
   border: solid 3px green;
   border-radius: 10px;
@@ -42,7 +42,7 @@
   display: block;
   border-radius: 10px;
   position: fixed;
-  left: 70px;
+  left: 0px;
   top: 340px;
 }
 .table_width {
@@ -94,7 +94,8 @@
   top: 150px;
 }
 .egg {
-  width: 300px;
+  position: fixed;
+  width: 20%;
   height: 500px;
   background-image: image_url('egg.jpg');
   background-size: cover;

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,6 +7,7 @@
 
     <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
+    <meta name="viewport" content="width=device-width,initial-scale=1.0,minimum-scale=1.0,maximum-scale=2.0,user-scalable=yes">
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css">
     <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js"></script>

--- a/app/views/records/my_daily.html.erb
+++ b/app/views/records/my_daily.html.erb
@@ -1,9 +1,9 @@
+<div class="ml-5 my_target day_record_style text-center font-weight-bold">
+  <%= t('activerecord.attributes.user.protein_target')  + ": " + current_user.protein_target.to_s + " g" %>
+</div>
 <div class="d-flex flex-column justify-content-center align-items-center">
   <div class="mb-3">
     <h1 class="food_text"><%= t('view.my_daily_record') %></h1>
-  </div>
-  <div class="my_target day_record_style text-center font-weight-bold ml-5">
-    <%= t('activerecord.attributes.user.protein_target')  + ": " + current_user.protein_target.to_s + " g" %>
   </div>
   <div class="d-flex flex-row justify-content-center align-items-center">
     <div class="d-flex flex-column justify-content-center align-items-center ml-3">

--- a/app/views/records/my_daily.html.erb
+++ b/app/views/records/my_daily.html.erb
@@ -2,11 +2,11 @@
   <div class="mb-3">
     <h1 class="food_text"><%= t('view.my_daily_record') %></h1>
   </div>
+  <div class="my_target day_record_style text-center font-weight-bold ml-5">
+    <%= t('activerecord.attributes.user.protein_target')  + ": " + current_user.protein_target.to_s + " g" %>
+  </div>
   <div class="d-flex flex-row justify-content-center align-items-center">
-    <div class="my_target day_record_style text-center font-weight-bold mr-5 ">
-      <%= t('activerecord.attributes.user.protein_target')  + ": " + current_user.protein_target.to_s + " g" %>
-    </div>
-    <div class="d-flex flex-column justify-content-center align-items-center ml-5">
+    <div class="d-flex flex-column justify-content-center align-items-center ml-3">
       <div class="paginate_box rounded mt-3">
         <%= paginate @days, window: 3 %>
       </div>
@@ -63,5 +63,5 @@
       </div>
     </div>
   </div>
+  <div class="egg index_picture_margin picture_position_right"></div>
 </div>
-<div class="egg index_picture_margin picture_position_right"></div>


### PR DESCRIPTION
1. ブラウザのウィンドウ幅を狭めた時、各ページで写真が文字の上に被らないように修正