### PR TITLE
修正：herokuでBMIのページの表示位置ズレ修正 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -161,6 +161,8 @@ GEM
     nio4r (2.5.7)
     nokogiri (1.11.7-x86_64-darwin)
       racc (~> 1.4)
+    nokogiri (1.11.7-x86_64-linux)
+      racc (~> 1.4)
     orm_adapter (0.5.0)
     parallel (1.20.1)
     parser (3.0.1.1)
@@ -334,6 +336,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-19
+  x86_64-linux
 
 DEPENDENCIES
   bootsnap (>= 1.1.0)

--- a/app/views/bmis/_form.html.erb
+++ b/app/views/bmis/_form.html.erb
@@ -3,12 +3,12 @@
     <div class="row mt-5">
       <div class="col-3"><%= f.label :height %></div>
       <div class="col-5"><%= f.number_field :height, min: '1', placeholder: t('view.input_integer') %></div>
-      <div class="col-1">cm</div>
+      <div class="col-2 ml-4">cm</div>
     </div>
     <div class="row mt-4">
       <div class="col-3"><%= f.label :weight %></div>
       <div class="col-5"><%= f.number_field :weight, min: '0.1' ,step: '0.1', placeholder: t('view.input_float'), autofocus: true %></div>
-      <div class="col-1">kg</div>
+      <div class="col-2 ml-4">kg</div>
     </div>
     <div class="row mt-4">
       <div class="col-3"><%= f.label :record_on %></div>


### PR DESCRIPTION
1. herokuでBMIのページの表示位置ズレ修正 