### PR TITLE
追加： 返信機能の各ページにcss設定

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -10,6 +10,7 @@ body {
   flex-direction: column;
 }
 .body_wrapper {
+  overflow-wrap : break-word;
   flex: 1;
 }
 .background_color {

--- a/app/assets/stylesheets/reply.scss
+++ b/app/assets/stylesheets/reply.scss
@@ -3,3 +3,25 @@
 .reply_index_wrapper {
   min-height: 150px;
 }
+.reply_content_title {
+  padding-top: 10px;
+}
+.reply_content_area {
+  background: #fff;
+  border: solid 1px rgb(134, 129, 129);
+  box-shadow: 2px 2px rgb(134, 129, 129);
+  border-radius: 15px;
+  width: 90%;
+  padding: 10px;
+}
+.reply_name_content {
+  font-size: 1.3rem;
+  color: rgb(23, 24, 23);
+  text-shadow: 1px 1px #fff;
+  border-bottom: solid 2px rgb(0, 0, 0);
+  min-width: 60px;
+  padding: 10px 0 0 0;
+}
+.reply_name_area {
+  padding-top: 8px;
+}

--- a/app/views/contacts/edit.html.erb
+++ b/app/views/contacts/edit.html.erb
@@ -2,7 +2,7 @@
   <div>
     <h1 class="food_text"><%= t('view.contact_edit') %></h1>
   </div>
-  <div>
+  <div class="contact_area">
     <%= render 'form', food: @contact %>
   </div>
 </div>

--- a/app/views/contacts/index.html.erb
+++ b/app/views/contacts/index.html.erb
@@ -1,18 +1,18 @@
 <div class="d-flex flex-column justify-content-center align-items-center contact_show_wrapper day_record_style bg-white mt-5">
   <h1 class="food_text"><%= t('view.contact_index') %></h1>
   <div class="row row_index">
-    <div class="col-3 text-center font-weight-bold text-success my-3"><%= t('activerecord.attributes.user.name') %></div>
-    <div class="col-3 text-center font-weight-bold text-success my-3"><%= t('activerecord.attributes.contact.title') %></div>
-    <div class="col-3 text-center font-weight-bold text-success my-3"><%= t('view.button') %></div>
+    <div class="col-4 text-center font-weight-bold text-success my-3"><%= t('activerecord.attributes.user.name') %></div>
+    <div class="col-4 text-center font-weight-bold text-success my-3"><%= t('activerecord.attributes.contact.title') %></div>
+    <div class="col-4 text-center font-weight-bold text-success my-3"><%= t('view.button') %></div>
   </div>
   <% if @contacts != nil %>
     <% @contacts.each do |contact| %>
       <div class="row row_index">
-        <div class="col-3 text-center my-3"><%= contact.user.name %></div>
-        <div class="col-3 text-center my-3"><%= contact.title %></div>
-        <div class="col-3 text-center">
-          <%= link_to t('view.show'), contact_path(contact.id), class: "btn btn-outline-success" %>
-          <%= link_to t('view.destroy'), contact_path(contact.id), method: :delete, data: { confirm: 'Are you sure?' }, class: "btn btn-outline-warning" %>
+        <div class="col-4 text-center my-3"><%= contact.user.name %></div>
+        <div class="col-4 text-center my-3"><%= contact.title %></div>
+        <div class="col-4 text-center">
+          <%= link_to t('view.show'), contact_path(contact.id), class: "btn btn-outline-success mt-2" %>
+          <%= link_to t('view.destroy'), contact_path(contact.id), method: :delete, data: { confirm: 'Are you sure?' }, class: "btn btn-outline-warning mt-2" %>
         </div>
       </div>
     <% end %>

--- a/app/views/contacts/new.html.erb
+++ b/app/views/contacts/new.html.erb
@@ -2,7 +2,7 @@
   <div>
     <h1 class="food_text"><%= t('view.contact_new') %></h1>
   </div>
-  <div>
+  <div class="contact_area">
     <%= render 'form', food: @contact %>
   </div>
 </div>

--- a/app/views/contacts/show.html.erb
+++ b/app/views/contacts/show.html.erb
@@ -23,12 +23,14 @@
           <div class="col-9 text-left reply_name_area"><span class="reply_name_content"><%= reply.contact.user.name %></span></div>
           <div class="col-3 text-left reply_content_title mt-4"><%= label :comment, t('activerecord.attributes.reply.comment'), class: "text-success" %></div>
           <div class="col-9 text-left reply_content_area mt-4"><%= reply.comment %></div>
-          <div class="button_design submit_button mt-5 mx-3">
-            <%= link_to t('view.edit'), edit_reply_path(id: reply.id, contact_id: @contact.id), class: "button_text_color" %>
-          </div>
-          <div class="button_design submit_button mt-5 mx-3">
-            <%= link_to t('view.destroy'), reply_path(id: reply.id), method: :delete, data: { confirm: 'Are you sure?' }, class: "button_text_color" %>
-          </div>
+          <% if reply.replier_id == current_user.id %>
+            <div class="button_design submit_button mt-5 mx-3">
+              <%= link_to t('view.edit'), edit_reply_path(id: reply.id, contact_id: @contact.id), class: "button_text_color" %>
+            </div>
+            <div class="button_design submit_button mt-5 mx-3">
+              <%= link_to t('view.destroy'), reply_path(id: reply.id), method: :delete, data: { confirm: 'Are you sure?' }, class: "button_text_color" %>
+            </div>
+          <% end %>
           <br>
         </div>
       <% end %>

--- a/app/views/contacts/show.html.erb
+++ b/app/views/contacts/show.html.erb
@@ -20,7 +20,7 @@
       <% @replies.each do |reply| %>
         <div class="mx-3 mt-3 row contact_area">
           <div class="col-3 text-left reply_content_title" ><%= label :replier_id, t('activerecord.attributes.reply.replier_id'), class: "text-success" %></div>
-          <div class="col-9 text-left reply_name_area"><span class="reply_name_content"><%= reply.contact.user.name %></span></div>
+          <div class="col-9 text-left reply_name_area"><span class="reply_name_content"><%= User.find(reply.replier_id).name %></span></div>
           <div class="col-3 text-left reply_content_title mt-4"><%= label :comment, t('activerecord.attributes.reply.comment'), class: "text-success" %></div>
           <div class="col-9 text-left reply_content_area mt-4"><%= reply.comment %></div>
           <% if reply.replier_id == current_user.id %>

--- a/app/views/contacts/show.html.erb
+++ b/app/views/contacts/show.html.erb
@@ -1,39 +1,45 @@
 <div class="d-flex flex-column justify-content-center align-items-center contact-show_wrapper day_record_style bg-white mt-5">
   <h1 class="food_text mt-3"><%= t('view.contact_show') %></h1>
-  <div class=" mt-5 contact_container">
+  <div class="reply_index_wrapper d-flex flex-column justify-content-left container">
     <div class="mx-3 mt-3 row contact_area">
-      <div class="col-4"><%= label :name, t('activerecord.attributes.contact.title'), class: "text-success" %></div>
-      <div class="col-8 text-left pt-1"><%= @contact.title %></div>
-    </div>
-    <div class="mx-3 mt-3 row contact_area">
-      <div class="col-4"><%= label :protein, t('activerecord.attributes.contact.content'), class: "text-success" %></div>
-      <div class="col-8 text-left pt-1"><%= @contact.content %></div>
+      <div class="col-3 text-left reply_content_title mt-4"><%= label :name, t('activerecord.attributes.contact.title'), class: "text-success" %></div>
+      <div class="col-9 text-left reply_content_area mt-4"><%= @contact.title %></div>
+      <div class="col-3 text-left reply_content_title mt-4"><%= label :protein, t('activerecord.attributes.contact.content'), class: "text-success" %></div>
+      <div class="col-9 text-left reply_content_area mt-4"><%= @contact.content %></div>
+      <div class="button_design submit_button mt-5 mx-3">
+        <%= link_to t('view.edit'), edit_contact_path(@contact.id), class: "button_text_color" %>
+      </div>
+      <div class="button_design submit_button mt-5 my-2 mx-3">
+        <%= link_to t('view.back'), contacts_path, class: "button_text_color" %>
+      </div>
     </div>
   </div>
-  <div class="d-flex flex-row justify-content-center align-items-center mt-3">
-    <div class="button_design submit_button mt-5 mx-3">
-      <%= link_to t('view.edit'), edit_contact_path(@contact.id), class: "button_text_color" %>
-    </div>
-    <div class="button_design submit_button mt-5 my-2 mx-3">
-      <%= link_to t('view.back'), contacts_path, class: "button_text_color" %>
-    </div>
-  </div>
-  <div class="food_text my-3"><h3><%= t('view.reply_index') %></h3></div>
+  <div class="food_text my-3"><h1><%= t('view.reply_index') %></h1></div>
   <div class="reply_index_wrapper d-flex flex-column justify-content-left container">
     <% if @replies != nil %>
       <% @replies.each do |reply| %>
         <div class="mx-3 mt-3 row contact_area">
-          <div>
-            <div class="col-12 text-left" ><%= label :replier_id, t('activerecord.attributes.reply.replier_id'), class: "text-success" %></div>
-            <div><%= reply.contact.user.name %></div>
+          <div class="col-3 text-left reply_content_title" ><%= label :replier_id, t('activerecord.attributes.reply.replier_id'), class: "text-success" %></div>
+          <div class="col-9 text-left reply_name_area"><span class="reply_name_content"><%= reply.contact.user.name %></span></div>
+          <div class="col-3 text-left reply_content_title mt-4"><%= label :comment, t('activerecord.attributes.reply.comment'), class: "text-success" %></div>
+          <div class="col-9 text-left reply_content_area mt-4"><%= reply.comment %></div>
+          <div class="button_design submit_button mt-5 mx-3">
+            <%= link_to t('view.edit'), edit_reply_path(id: reply.id, contact_id: @contact.id), class: "button_text_color" %>
           </div>
-          <div class="col-12 text-left"><%= label :comment, t('activerecord.attributes.reply.comment'), class: "text-success" %><%= reply.comment %></div>
-          <%= link_to t('view.edit'), edit_reply_path(id: reply.id, contact_id: @contact.id) %>
-          <%= link_to t('view.destroy'), reply_path(id: reply.id), method: :delete, data: { confirm: 'Are you sure?' }, class: "btn btn-outline-warning" %>
+          <div class="button_design submit_button mt-5 mx-3">
+            <%= link_to t('view.destroy'), reply_path(id: reply.id), method: :delete, data: { confirm: 'Are you sure?' }, class: "button_text_color" %>
+          </div>
           <br>
         </div>
       <% end %>
     <% end %>
   </div>
-  <%= link_to t('view.reply_new'), new_reply_path(contact_id: @contact.id) %>
+  <div class="reply_index_wrapper d-flex flex-row justify-content-left">
+    <div class="button_design submit_button mx-5 mt-4">
+      <%= link_to t('view.reply_new'), new_reply_path(contact_id: @contact.id), class: "button_text_color" %>
+    </div>
+    <div class="button_design submit_button mx-5 mt-4">
+      <%= link_to t('view.back'), contacts_path, class: "button_text_color" %>
+    </div>
+  </div>
 </div>

--- a/app/views/replies/_form.html.erb
+++ b/app/views/replies/_form.html.erb
@@ -1,7 +1,7 @@
-<div class="d-flex flex-column justify-content-center align-items-center contact_new_wrapper container">
+<div class="d-flex flex-column justify-content-center align-items-center contact_area container">
   <%= form_with(model: @reply, local: true ) do |f| %>
     <div class="row mt-4">
-      <div class="col-3"><%= f.label :comment %></div>
+      <div class="col-3"><%= f.label :comment, class: "text-success" %></div>
       <div class="col-9"><%= f.text_area :comment, placeholder: t('view.input_less_than1000'), class: "contact_form_content" %></div>
     </div>
     <%= f.hidden_field :replier_id, value: current_user.id %>


### PR DESCRIPTION
1.  お問合せ一覧ページ
2. 返信作成ページ
3. 返信編集ページ

修正
1. 返信者にお問合せ作成者のユーザー名が表示されるのを修正
2. 自身の返信でなくても編集・削除ボタンが表示されるのを修正