### PR TITLE
修正：プロフィールのボタン及びユーザー削除の不具合修正 

### DIFF
--- a/app/models/food.rb
+++ b/app/models/food.rb
@@ -4,7 +4,7 @@ class Food < ApplicationRecord
   validates :quantity, presence: true, numericality: { only_integer: true, greater_than: 0 }
   validates :unit, presence: true, length: { in: 1..10 }
   belongs_to :user
-  has_many :nutrition_record_lines
+  has_many :nutrition_record_lines, dependent: :destroy
 
   scope :pick_food, lambda { |food_id|
     find_by('id = ?', food_id)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,4 @@
 class User < ApplicationRecord
-  before_validation { email.downcase! }
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -39,14 +39,14 @@
           <div class="d-flex flex-row justify-content-center mt-5">
             <div class="index_picture_margin cat_before mr-5"></div>
             <div class="cat_after mr-5"></div>
-            <div class="button_design m-4">
-              <%= link_to t('view.edit'), edit_user_registration_path(@user.id), class: "button_text_color" %>
-            </div>
             <% if @user != current_user %>
               <div class="m-4">
-                <%= render 'follow_form', user: @user if @user != current_user %>
+                <%= render 'follow_form', user: @user %>
               </div>
             <% else %>
+              <div class="button_design m-4">
+                <%= link_to t('view.edit'), edit_user_registration_path(@user.id), class: "button_text_color" %>
+              </div>
               <div class="m-4 button_design">
                 <%= link_to "BMI", bmis_path, class: "button_text_color" %>
               </div>
@@ -56,9 +56,6 @@
                 <%= link_to t('view.admin_dashboard'), rails_admin_path, class: "button_text_color" %>
               </div>
             <% end %>
-            <div class="m-4 button_design admin_dashboard_button">
-              <%= link_to t('view.user_guide'), user_guide_index_path, class: "button_text_color" %>
-            </div>
           </div>
         </div>
       </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
   }
   devise_scope :user do
     post 'users/guest_sign_in', to: 'users/sessions#new_guest'
-    get '/users/sign_out', to: 'devise/sessions#destroy'
+    get '/users/sign_out', to: 'users/sessions#destroy'
   end
   resources :users, only: %i[index show]
   resources :bmis, except: :show


### PR DESCRIPTION
プロフィールのボタン及びユーザー削除の不具合修正として以下を実施

1. 他人のプロフィールに飛んだ時フォロー以外のボタンが表示されないように修正
2. 食事記録を作成したユーザーが外部キー制約不足により削除できなくなっていた為、Foodモデルのアソシエーションにdependent: :destroy追加