### PR TITLE
修正：カレンダーで先月・翌月に遷移するとウィンドウが閉じる為修正 

### DIFF
--- a/app/assets/stylesheets/bmi.scss
+++ b/app/assets/stylesheets/bmi.scss
@@ -57,20 +57,8 @@
 }
 .graph_button_container {
   width: 100%;
-  display: flex;
-  flex-direction: row;
-  justify-content: flex-end;
-  margin: 0 30% 2px -5px;
-}
-#graph_modal_button {
-  width: 90px;
-  height: 20px;
-  font-size: 1rem;
-  line-height: 10px;
-  border-radius: 10px;
-  z-index: 1;
-  margin-left: 20%;
-  margin-top: 4px;
+  height: 30px;
+  margin: 0 0 1% 24%;
 }
 .graph_paginate {
   margin-right: 12.5%;

--- a/app/controllers/nutrition_records_controller.rb
+++ b/app/controllers/nutrition_records_controller.rb
@@ -55,9 +55,12 @@ class NutritionRecordsController < ApplicationController
   end
 
   def my_daily
-    @calendar_elements = current_user.nutrition_records.order(start_time: :desc)
-    @nutrition_records = @calendar_elements.page(params[:page]).per(5)
+    @nutrition_records = current_user.nutrition_records.order(start_time: :desc).page(params[:page]).per(5)
     @nutrition_record_lines = @nutrition_records.map { |line| line.nutrition_record_lines }
+  end
+
+  def my_calendar
+    @calendar_elements = current_user.nutrition_records.order(start_time: :desc)
   end
 
   private

--- a/app/views/bmis/index.html.erb
+++ b/app/views/bmis/index.html.erb
@@ -2,7 +2,7 @@
   <div class="bmi_index_wrapper">
     <div class="d-flex flex-column justify-content-center align-items-center">
       <h1 class="main_title p-2"><%= t('view.bmi_index') %><%= render 'layouts/flash_message' %></h1>
-      <div class="graph_button_container">
+      <div class="graph_button_container d-flex flex-row justify-content-center">
         <div class="graph_paginate"><%= paginate @bmis, window: 3 %></div>
         <button type="button" class="btn btn-primary ml-3" data-toggle="modal" data-target="#Modal", id="graph_modal_button">
           BMIグラフ

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,65 +19,61 @@
       <%= yield %>
     <% else %>
       <div class="top_image body_wrapper">
-        <% if user_signed_in? %>
-          <nav class="navbar navbar-expand-lg navbar-light bg-light fixed-top">
-        <% else %>
-          <nav class="navbar navbar-top navbar-expand-lg navbar-light bg-light fixed-top">
-        <% end %>
-        <%= link_to 'プロマネ', "/", class: "logo" %>
-        <% if user_signed_in? %>
-          <ul class="navbar-nav mr-auto">
-            <li class="header_user_name">
-              <%= t('view.user_name') %>: <%= current_user.name %>
-              <%= "admin" if current_user.admin == true %>
-            </li>
-          </ul>
-        <% end %>
-        <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-          <span class="navbar-toggler-icon"></span>
-        </button>
-        <div class="collapse navbar-collapse justify-content-end" id="navbarSupportedContent">
+        <nav class="navbar navbar-expand-lg navbar-light bg-light fixed-top">
+          <%= link_to 'プロマネ', "/", class: "logo" %>
           <% if user_signed_in? %>
-            <ul class="navbar-nav navbar-right">
-              <% if controller_name == "nutrition_records" && (action_name == "my_daily" || action_name == "index") || controller_name == "bmis" && action_name == "index"  %>
-                <div class="dropdown">
-                  <button type="button" id="dropdown1" class="btn btn-secondary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                    メインコンテンツ
-                  </button>
-                  <div class="dropdown-menu" aria-labelledby="dropdown1">
-                    <li class="dropdown_item"><%= link_to t('view.food_new'), new_food_path, class: "px-2 nav-link" %></li>
-                    <li class="dropdown_item"><%= link_to t('view.foods_index'), foods_path, class: "px-2 nav-link" %></li>
-                    <li class="dropdown_item"><%= link_to t('view.record_new'), new_nutrition_record_path, class: "px-2 nav-link" %></li>
-                    <li class="dropdown_item"><%= link_to t('view.my_daily_record'), my_daily_nutrition_record_path(current_user.id), class: "px-2 nav-link" %></li>
-                    <li class="dropdown_item"><%= link_to t('view.records_index'), nutrition_records_path, class: "px-2 nav-link" %></li>
-                  </div>
-                </div>
-                <div class="dropdown">
-                  <button type="button" id="dropdown2" class="btn btn-secondary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                    サブコンテンツ
-                  </button>
-                  <div class="dropdown-menu" aria-labelledby="dropdown1">
-                    <li class="dropdown_item"><%= link_to t('view.profile'), user_path(current_user.id), class: "nav-link" %></li>
-                    <li class="dropdown_item"><%= link_to t('view.follow'), users_path, class: "nav-link" %></li>
-                    <li class="dropdown_item"><%= link_to t('view.contact'), contacts_path, class: "nav-link" %></li>
-                  </div>
-                </div>
-              <% else %>
-                <li class="nav-item"><%= link_to t('view.profile'), user_path(current_user.id), class: "nav-link" %></li>
-                <li class="nav-item"><%= link_to t('view.follow'), users_path, class: "nav-link" %></li>
-                <li class="nav-item"><%= link_to t('view.contact'), contacts_path, class: "nav-link" %></li>
-              <% end %>
-              <li class="nav-item"><%= link_to t('view.logout'), destroy_user_session_path, method: :delete, class: "nav-link" %></li>
-            </ul>
-          <% else %>
             <ul class="navbar-nav mr-auto">
-              <%= link_to t('view.guest_login'), users_guest_sign_in_path, method: :post, class: "login nav-link", id: "guest_login" %></li>
-              <%= link_to t('view.sign_up'), new_user_registration_path, class: "nav-link" %>
-              <%= link_to t('view.login'), new_user_session_path, class: "nav-link" %>
-              <%= link_to t('view.user_guide'), user_guide_index_path, class: "nav-link" %>
+              <li class="header_user_name">
+                <%= t('view.user_name') %>: <%= current_user.name %>
+                <%= "admin" if current_user.admin == true %>
+              </li>
             </ul>
           <% end %>
-        </div>
+          <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+            <span class="navbar-toggler-icon"></span>
+          </button>
+          <div class="collapse navbar-collapse justify-content-end" id="navbarSupportedContent">
+            <% if user_signed_in? %>
+              <ul class="navbar-nav navbar-right">
+                <% if controller_name == "nutrition_records" && (action_name == "my_daily" || action_name == "index") || controller_name == "bmis" && action_name == "index"  %>
+                  <div class="dropdown">
+                    <button type="button" id="dropdown1" class="btn btn-secondary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                      メインコンテンツ
+                    </button>
+                    <div class="dropdown-menu" aria-labelledby="dropdown1">
+                      <li class="dropdown_item"><%= link_to t('view.food_new'), new_food_path, class: "px-2 nav-link" %></li>
+                      <li class="dropdown_item"><%= link_to t('view.foods_index'), foods_path, class: "px-2 nav-link" %></li>
+                      <li class="dropdown_item"><%= link_to t('view.record_new'), new_nutrition_record_path, class: "px-2 nav-link" %></li>
+                      <li class="dropdown_item"><%= link_to t('view.my_daily_record'), my_daily_nutrition_record_path(current_user.id), class: "px-2 nav-link" %></li>
+                      <li class="dropdown_item"><%= link_to t('view.records_index'), nutrition_records_path, class: "px-2 nav-link" %></li>
+                    </div>
+                  </div>
+                  <div class="dropdown">
+                    <button type="button" id="dropdown2" class="btn btn-secondary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                      サブコンテンツ
+                    </button>
+                    <div class="dropdown-menu" aria-labelledby="dropdown1">
+                      <li class="dropdown_item"><%= link_to t('view.profile'), user_path(current_user.id), class: "nav-link" %></li>
+                      <li class="dropdown_item"><%= link_to t('view.follow'), users_path, class: "nav-link" %></li>
+                      <li class="dropdown_item"><%= link_to t('view.contact'), contacts_path, class: "nav-link" %></li>
+                    </div>
+                  </div>
+                <% else %>
+                  <li class="nav-item"><%= link_to t('view.profile'), user_path(current_user.id), class: "nav-link" %></li>
+                  <li class="nav-item"><%= link_to t('view.follow'), users_path, class: "nav-link" %></li>
+                  <li class="nav-item"><%= link_to t('view.contact'), contacts_path, class: "nav-link" %></li>
+                <% end %>
+                <li class="nav-item"><%= link_to t('view.logout'), destroy_user_session_path, method: :delete, class: "nav-link" %></li>
+              </ul>
+            <% else %>
+              <ul class="navbar-nav mr-auto">
+                <%= link_to t('view.guest_login'), users_guest_sign_in_path, method: :post, class: "login nav-link", id: "guest_login" %></li>
+                <%= link_to t('view.sign_up'), new_user_registration_path, class: "nav-link" %>
+                <%= link_to t('view.login'), new_user_session_path, class: "nav-link" %>
+                <%= link_to t('view.user_guide'), user_guide_index_path, class: "nav-link" %>
+              </ul>
+            <% end %>
+          </div>
         </nav>
         <%= yield %>
       </div>
@@ -89,3 +85,13 @@
     <% end %>
   </body>
 </html>
+
+<script>
+  $(function() {
+    if($('.main_sentence').length) {
+      $("nav").addClass("navbar-top");
+    } else {
+      $("nav").removeClass("navbar-top");
+    }
+  });
+</script>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,12 +15,15 @@
   </head>
 
   <body>
-    <div class="top_image body_wrapper">
-      <% if user_signed_in? %>
-        <nav class="navbar navbar-expand-lg navbar-light bg-light fixed-top">
-      <% else %>
-        <nav class="navbar navbar-top navbar-expand-lg navbar-light bg-light fixed-top">
-      <% end %>
+    <% if controller_name == "nutrition_records" && action_name == "my_calendar" %>
+      <%= yield %>
+    <% else %>
+      <div class="top_image body_wrapper">
+        <% if user_signed_in? %>
+          <nav class="navbar navbar-expand-lg navbar-light bg-light fixed-top">
+        <% else %>
+          <nav class="navbar navbar-top navbar-expand-lg navbar-light bg-light fixed-top">
+        <% end %>
         <%= link_to 'プロマネ', "/", class: "logo" %>
         <% if user_signed_in? %>
           <ul class="navbar-nav mr-auto">
@@ -38,11 +41,7 @@
             <ul class="navbar-nav navbar-right">
               <% if controller_name == "nutrition_records" && (action_name == "my_daily" || action_name == "index") || controller_name == "bmis" && action_name == "index"  %>
                 <div class="dropdown">
-                  <button type="button" id="dropdown1"
-                      class="btn btn-secondary dropdown-toggle"
-                      data-toggle="dropdown"
-                      aria-haspopup="true"
-                      aria-expanded="false">
+                  <button type="button" id="dropdown1" class="btn btn-secondary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                     メインコンテンツ
                   </button>
                   <div class="dropdown-menu" aria-labelledby="dropdown1">
@@ -54,11 +53,7 @@
                   </div>
                 </div>
                 <div class="dropdown">
-                  <button type="button" id="dropdown2"
-                      class="btn btn-secondary dropdown-toggle"
-                      data-toggle="dropdown"
-                      aria-haspopup="true"
-                      aria-expanded="false">
+                  <button type="button" id="dropdown2" class="btn btn-secondary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                     サブコンテンツ
                   </button>
                   <div class="dropdown-menu" aria-labelledby="dropdown1">
@@ -83,10 +78,11 @@
             </ul>
           <% end %>
         </div>
-      </nav>
-      <%= yield %>
-    </div>
-    <% if (controller_name != "top" || controller_name == "user_guide") && !((controller_name == "sessions" || controller_name == "registrations" ) && (action_name == "new" || action_name == "create" )) %>
+        </nav>
+        <%= yield %>
+      </div>
+    <% end %>
+    <% if (controller_name != "top" || controller_name == "user_guide") && !((controller_name == "sessions" || controller_name == "registrations" ) && (action_name == "new" || action_name == "create" )) && !((controller_name == "nutrition_records" ) && (action_name == "my_calendar" )) %>
       <footer class="footer fixed-bottom">
         <li id="copy_right">&copy; tetsuya</li>
       </footer>

--- a/app/views/nutrition_records/_calendar.html.erb
+++ b/app/views/nutrition_records/_calendar.html.erb
@@ -1,8 +1,0 @@
-<%= month_calendar events: @calendar_elements do |date, nutrition_records| %>
-  <div>
-    <%= "#{date.day}日" %>
-  </div>
-  <div>
-    <%= "#{NutritionRecord.sum_protein(nutrition_records)}g" if nutrition_records.length > 0 %>
-  </div>
-<% end %>

--- a/app/views/nutrition_records/my_calendar.html.erb
+++ b/app/views/nutrition_records/my_calendar.html.erb
@@ -13,9 +13,9 @@
 </div>
 
 <script>
-$(function() {
-  $('#close_calendar').on('click', function(e) {
-    window.close();
+  $(function() {
+    $('#close_calendar').on('click', function(e) {
+      window.close();
+    });
   });
-});
 </script>

--- a/app/views/nutrition_records/my_calendar.html.erb
+++ b/app/views/nutrition_records/my_calendar.html.erb
@@ -1,0 +1,21 @@
+<div class="d-flex flex-column justify-content-start align-items-center">
+  <%= month_calendar events: @calendar_elements do |date, nutrition_records| %>
+    <div>
+      <%= "#{date.day}日" %>
+    </div>
+    <div>
+      <%= "#{NutritionRecord.sum_protein(nutrition_records)}g" if nutrition_records.length > 0 %>
+    </div>
+  <% end %>
+  <div class="row justify-content-center mb-3">
+    <%= link_to t('view.close'), "#", id: "close_calendar", class: "btn btn-primary" %>
+  </div>
+</div>
+
+<script>
+$(function() {
+  $('#close_calendar').on('click', function(e) {
+    window.close();
+  });
+});
+</script>

--- a/app/views/nutrition_records/my_daily.html.erb
+++ b/app/views/nutrition_records/my_daily.html.erb
@@ -70,12 +70,12 @@
 </div>
 
 <script>
-$(function() {
-  $('#my_calendar').on('click', function(e) {
-    width_locate = window.innerWidth / 2 - 237;
-    height_locate = window.innerHeight / 5;
-    window.open(this.href, 'my_calendar', 'width=475 height=610' + ',' + 'top=' + height_locate + ',' + 'left=' + width_locate );
-    return false;
+  $(function() {
+    $('#my_calendar').on('click', function(e) {
+      width_locate = window.innerWidth / 2 - 237;
+      height_locate = window.innerHeight / 5;
+      window.open(this.href, 'my_calendar', 'width=475 height=610' + ',' + 'top=' + height_locate + ',' + 'left=' + width_locate );
+      return false;
+    });
   });
-});
 </script>

--- a/app/views/nutrition_records/my_daily.html.erb
+++ b/app/views/nutrition_records/my_daily.html.erb
@@ -11,9 +11,7 @@
         <div class="paginate_box rounded mt-2">
           <%= paginate @nutrition_records, window: 3 %>
         </div>
-        <button type="button" class="btn btn-primary mb-2 ml-5" data-toggle="modal" data-target="#Modal", id="modal_button">
-          カレンダー
-        </button>
+        <%= link_to "カレンダー", my_calendar_nutrition_record_path(current_user.id), id: "my_calendar", class: "btn btn-primary mb-2 ml-5"%>
       </div>
       <div class="nutrition_record_my_daily_container scroll">
         <div class="d-flex flex-column justify-content-center align-items-center ml-3">
@@ -70,23 +68,14 @@
     </div>
   </div>
 </div>
-<div class="modal_contents_container">
-  <div class="modal fade" id="Modal" tabindex="-1" role="dialog" aria-labelledby="Modal" aria-hidden="true">
-    <div class="modal-dialog modalog" role="document">
-      <div class="modal-content">
-        <div class="modal-header">
-          <h5 class="modal-title" id="Modal">タンパク質カレンダー</h5>
-          <button type="button" class="close" data-dismiss="modal" aria-label="閉じる">
-            <span aria-hidden="true">&times;</span>
-          </button>
-        </div>
-        <div class="modal-body">
-          <%= render 'calendar', record: @calendar_elements %>
-        </div>
-        <div class="modal-footer">
-          <button type="button" class="btn btn-secondary" data-dismiss="modal" id="close_button">閉じる</button>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
+
+<script>
+$(function() {
+  $('#my_calendar').on('click', function(e) {
+    width_locate = window.innerWidth / 2 - 237;
+    height_locate = window.innerHeight / 5;
+    window.open(this.href, 'my_calendar', 'width=475 height=610' + ',' + 'top=' + height_locate + ',' + 'left=' + width_locate );
+    return false;
+  });
+});
+</script>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -218,6 +218,7 @@ ja:
     update: 更新
     new_user: ユーザー作成
     submit: 登録
+    close: 閉じる
     sign_up: サインアップ
     login: ログイン
     guest_login: ゲストログイン

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
   resources :foods
   resources :nutrition_records do
     get 'my_daily', on: :member
+    get 'my_calendar', on: :member
   end
   resources :nutrition_record_lines, only: %i[destroy]
   resources :friendships, only: %i[create destroy]


### PR DESCRIPTION
カレンダーをポップアップ表示にすると、翌月・先月に移動する際にウィンドウが閉じてしまい、再度カレンダーのボタンで起動させる必要があった。以下の方法にて修正。

カレンダー用のmy_calendarアクションとカレンダー用のhtmlファイルを作成。link_toで遷移する際にwindow.openで新規ウィンドウとして起動させる。

・その他の調整
1. BMIグラフのボタンの大きさをカレンダーに合わせて調整
2. コードのインデント調整の為、ヘッダーのcss分岐をif文からjQueryへ変更